### PR TITLE
Move the proguard rules into aar by consumerProguardFiles

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -183,12 +183,6 @@ AutoSizeConfig.getInstance().getUnitsManager()
         .setSupportSubunits(Subunits.MM);
 ```
 
-## ProGuard
-```
- -keep class me.jessyan.autosize.** { *; }
- -keep interface me.jessyan.autosize.** { *; }
-```
-
 
 ## Donate
 ![alipay](https://raw.githubusercontent.com/JessYanCoding/MVPArms/master/image/pay_alipay.jpg) ![](https://raw.githubusercontent.com/JessYanCoding/MVPArms/master/image/pay_wxpay.jpg)

--- a/README.md
+++ b/README.md
@@ -185,12 +185,6 @@ AutoSizeConfig.getInstance().getUnitsManager()
         .setSupportSubunits(Subunits.MM);
 ```
 
-## ProGuard
-```
- -keep class me.jessyan.autosize.** { *; }
- -keep interface me.jessyan.autosize.** { *; }
-```
-
 
 ## Donate
 ![alipay](https://raw.githubusercontent.com/JessYanCoding/MVPArms/master/image/pay_alipay.jpg) ![](https://raw.githubusercontent.com/JessYanCoding/MVPArms/master/image/pay_wxpay.jpg)

--- a/autosize/build.gradle
+++ b/autosize/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         versionCode rootProject.versionCode
         versionName rootProject.versionName
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     buildTypes {

--- a/autosize/proguard-rules.pro
+++ b/autosize/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class me.jessyan.autosize.** { *; }
+-keep interface me.jessyan.autosize.** { *; }


### PR DESCRIPTION
将需要混淆的配置放到aar内部，外部使用者不用关心混淆的配置。通过gradle的consumerProguardFiles配置，在打包成的aar或者发布到maven里的aar里，会生成proguard.txt文件，该文件会影响aar的使用者的编译混淆。另外需要发布新的jcenter版本才能将proguard.txt文件包含进去。