### PR TITLE
Add screenWidthDp and screenHeightDp support.

### DIFF
--- a/autosize/src/main/java/me/jessyan/autosize/AutoSize.java
+++ b/autosize/src/main/java/me/jessyan/autosize/AutoSize.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.app.Dialog;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.util.DisplayMetrics;
@@ -163,6 +164,8 @@ public final class AutoSize {
         int targetDensityDpi = 0;
         float targetScaledDensity = 0;
         float targetXdpi = 0;
+        int targetScreenWidthDp;
+        int targetScreenHeightDp;
 
         if (displayMetricsInfo == null) {
             if (isBaseOnWidth) {
@@ -175,26 +178,32 @@ public final class AutoSize {
             targetScaledDensity = targetDensity * scale;
             targetDensityDpi = (int) (targetDensity * 160);
 
+            targetScreenWidthDp = (int) (AutoSizeConfig.getInstance().getScreenWidth() / targetDensity);
+            targetScreenHeightDp = (int) (AutoSizeConfig.getInstance().getScreenHeight() / targetDensity);
+
             if (isBaseOnWidth) {
                 targetXdpi = AutoSizeConfig.getInstance().getScreenWidth() * 1.0f / subunitsDesignSize;
             } else {
                 targetXdpi = AutoSizeConfig.getInstance().getScreenHeight() * 1.0f / subunitsDesignSize;
             }
 
-            mCache.put(key, new DisplayMetricsInfo(targetDensity, targetDensityDpi, targetScaledDensity, targetXdpi));
+            mCache.put(key, new DisplayMetricsInfo(targetDensity, targetDensityDpi, targetScaledDensity, targetXdpi, targetScreenWidthDp, targetScreenHeightDp));
         } else {
             targetDensity = displayMetricsInfo.getDensity();
             targetDensityDpi = displayMetricsInfo.getDensityDpi();
             targetScaledDensity = displayMetricsInfo.getScaledDensity();
             targetXdpi = displayMetricsInfo.getXdpi();
+            targetScreenWidthDp = displayMetricsInfo.getScreenWidthDp();
+            targetScreenHeightDp = displayMetricsInfo.getScreenHeightDp();
         }
 
         setDensity(activity, targetDensity, targetDensityDpi, targetScaledDensity, targetXdpi);
+        setScreenSizeDp(activity, targetScreenWidthDp, targetScreenHeightDp);
 
-        LogUtils.d(String.format(Locale.ENGLISH, "The %s has been adapted! \n%s Info: isBaseOnWidth = %s, %s = %f, %s = %f, targetDensity = %f, targetScaledDensity = %f, targetDensityDpi = %d, targetXdpi = %f"
+        LogUtils.d(String.format(Locale.ENGLISH, "The %s has been adapted! \n%s Info: isBaseOnWidth = %s, %s = %f, %s = %f, targetDensity = %f, targetScaledDensity = %f, targetDensityDpi = %d, targetXdpi = %f, targetScreenWidthDp = %d, targetScreenHeightDp = %d"
                 , activity.getClass().getName(), activity.getClass().getSimpleName(), isBaseOnWidth, isBaseOnWidth ? "designWidthInDp"
                         : "designHeightInDp", sizeInDp, isBaseOnWidth ? "designWidthInSubunits" : "designHeightInSubunits", subunitsDesignSize
-                , targetDensity, targetScaledDensity, targetDensityDpi, targetXdpi));
+                , targetDensity, targetScaledDensity, targetDensityDpi, targetXdpi, targetScreenWidthDp, targetScreenHeightDp));
     }
 
     /**
@@ -217,6 +226,9 @@ public final class AutoSize {
                 , AutoSizeConfig.getInstance().getInitDensityDpi()
                 , AutoSizeConfig.getInstance().getInitScaledDensity()
                 , initXdpi);
+        setScreenSizeDp(activity
+                , AutoSizeConfig.getInstance().getInitScreenWidthDp()
+                , AutoSizeConfig.getInstance().getInitScreenHeightDp());
     }
 
     /**
@@ -289,6 +301,35 @@ public final class AutoSize {
                 break;
             default:
         }
+    }
+
+    /**
+     * 给 {@link Configuration} 赋值
+     *
+     * @param activity       {@link Activity}
+     * @param screenWidthDp  {@link Configuration#screenWidthDp}
+     * @param screenHeightDp {@link Configuration#screenHeightDp}
+     */
+    private static void setScreenSizeDp(Activity activity, int screenWidthDp, int screenHeightDp) {
+        if (AutoSizeConfig.getInstance().getUnitsManager().isSupportDP() && AutoSizeConfig.getInstance().getUnitsManager().isSupportScreenSizeDP()) {
+            Configuration activityConfiguration = activity.getResources().getConfiguration();
+            setScreenSizeDp(activityConfiguration, screenWidthDp, screenHeightDp);
+
+            Configuration appConfiguration = AutoSizeConfig.getInstance().getApplication().getResources().getConfiguration();
+            setScreenSizeDp(appConfiguration, screenWidthDp, screenHeightDp);
+        }
+    }
+
+    /**
+     * Configuration赋值
+     *
+     * @param configuration  {@link Configuration}
+     * @param screenWidthDp  {@link Configuration#screenWidthDp}
+     * @param screenHeightDp {@link Configuration#screenHeightDp}
+     */
+    private static void setScreenSizeDp(Configuration configuration, int screenWidthDp, int screenHeightDp) {
+        configuration.screenWidthDp = screenWidthDp;
+        configuration.screenHeightDp = screenHeightDp;
     }
 
     /**

--- a/autosize/src/main/java/me/jessyan/autosize/AutoSizeCompat.java
+++ b/autosize/src/main/java/me/jessyan/autosize/AutoSizeCompat.java
@@ -16,6 +16,7 @@
 package me.jessyan.autosize;
 
 import android.app.Activity;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.util.DisplayMetrics;
 
@@ -151,6 +152,8 @@ public final class AutoSizeCompat {
         int targetDensityDpi = 0;
         float targetScaledDensity = 0;
         float targetXdpi = 0;
+        int targetScreenWidthDp;
+        int targetScreenHeightDp;
 
         if (displayMetricsInfo == null) {
             if (isBaseOnWidth) {
@@ -163,21 +166,27 @@ public final class AutoSizeCompat {
             targetScaledDensity = targetDensity * scale;
             targetDensityDpi = (int) (targetDensity * 160);
 
+            targetScreenWidthDp = (int) (AutoSizeConfig.getInstance().getScreenWidth() / targetDensity);
+            targetScreenHeightDp = (int) (AutoSizeConfig.getInstance().getScreenHeight() / targetDensity);
+
             if (isBaseOnWidth) {
                 targetXdpi = AutoSizeConfig.getInstance().getScreenWidth() * 1.0f / subunitsDesignSize;
             } else {
                 targetXdpi = AutoSizeConfig.getInstance().getScreenHeight() * 1.0f / subunitsDesignSize;
             }
 
-            mCache.put(key, new DisplayMetricsInfo(targetDensity, targetDensityDpi, targetScaledDensity, targetXdpi));
+            mCache.put(key, new DisplayMetricsInfo(targetDensity, targetDensityDpi, targetScaledDensity, targetXdpi, targetScreenWidthDp, targetScreenHeightDp));
         } else {
             targetDensity = displayMetricsInfo.getDensity();
             targetDensityDpi = displayMetricsInfo.getDensityDpi();
             targetScaledDensity = displayMetricsInfo.getScaledDensity();
             targetXdpi = displayMetricsInfo.getXdpi();
+            targetScreenWidthDp = displayMetricsInfo.getScreenWidthDp();
+            targetScreenHeightDp = displayMetricsInfo.getScreenHeightDp();
         }
 
         setDensity(resources, targetDensity, targetDensityDpi, targetScaledDensity, targetXdpi);
+        setScreenSizeDp(resources, targetScreenWidthDp, targetScreenHeightDp);
     }
 
     /**
@@ -200,6 +209,9 @@ public final class AutoSizeCompat {
                 , AutoSizeConfig.getInstance().getInitDensityDpi()
                 , AutoSizeConfig.getInstance().getInitScaledDensity()
                 , initXdpi);
+        setScreenSizeDp(resources
+                , AutoSizeConfig.getInstance().getInitScreenWidthDp()
+                , AutoSizeConfig.getInstance().getInitScreenHeightDp());
     }
 
     /**
@@ -262,6 +274,35 @@ public final class AutoSizeCompat {
                 break;
             default:
         }
+    }
+
+    /**
+     * 给 {@link Configuration} 赋值
+     *
+     * @param resources      {@link Resources}
+     * @param screenWidthDp  {@link Configuration#screenWidthDp}
+     * @param screenHeightDp {@link Configuration#screenHeightDp}
+     */
+    private static void setScreenSizeDp(Resources resources, int screenWidthDp, int screenHeightDp) {
+        if (AutoSizeConfig.getInstance().getUnitsManager().isSupportDP() && AutoSizeConfig.getInstance().getUnitsManager().isSupportScreenSizeDP()) {
+            Configuration activityConfiguration = resources.getConfiguration();
+            setScreenSizeDp(activityConfiguration, screenWidthDp, screenHeightDp);
+
+            Configuration appConfiguration = AutoSizeConfig.getInstance().getApplication().getResources().getConfiguration();
+            setScreenSizeDp(appConfiguration, screenWidthDp, screenHeightDp);
+        }
+    }
+
+    /**
+     * Configuration赋值
+     *
+     * @param configuration  {@link Configuration}
+     * @param screenWidthDp  {@link Configuration#screenWidthDp}
+     * @param screenHeightDp {@link Configuration#screenHeightDp}
+     */
+    private static void setScreenSizeDp(Configuration configuration, int screenWidthDp, int screenHeightDp) {
+        configuration.screenWidthDp = screenWidthDp;
+        configuration.screenHeightDp = screenHeightDp;
     }
 
     /**

--- a/autosize/src/main/java/me/jessyan/autosize/AutoSizeConfig.java
+++ b/autosize/src/main/java/me/jessyan/autosize/AutoSizeConfig.java
@@ -73,6 +73,14 @@ public final class AutoSizeConfig {
      */
     private float mInitXdpi;
     /**
+     * 最初的 {@link Configuration#screenWidthDp}
+     */
+    private int mInitScreenWidthDp;
+    /**
+     * 最初的 {@link Configuration#screenHeightDp}
+     */
+    private int mInitScreenHeightDp;
+    /**
      * 设计图上的总宽度, 单位 dp
      */
     private int mDesignWidthInDp;
@@ -199,6 +207,7 @@ public final class AutoSizeConfig {
         this.mApplication = application;
         this.isBaseOnWidth = isBaseOnWidth;
         final DisplayMetrics displayMetrics = Resources.getSystem().getDisplayMetrics();
+        final Configuration configuration = Resources.getSystem().getConfiguration();
 
         getMetaData(application);
         isVertical = application.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
@@ -212,6 +221,8 @@ public final class AutoSizeConfig {
         mInitDensityDpi = displayMetrics.densityDpi;
         mInitScaledDensity = displayMetrics.scaledDensity;
         mInitXdpi = displayMetrics.xdpi;
+        mInitScreenWidthDp = configuration.screenWidthDp;
+        mInitScreenHeightDp = configuration.screenHeightDp;
         application.registerComponentCallbacks(new ComponentCallbacks() {
             @Override
             public void onConfigurationChanged(Configuration newConfig) {
@@ -477,6 +488,24 @@ public final class AutoSizeConfig {
      */
     public float getInitXdpi() {
         return mInitXdpi;
+    }
+
+    /**
+     * 获取 {@link #mInitScreenWidthDp}
+     *
+     * @return {@link #mInitScreenWidthDp}
+     */
+    public int getInitScreenWidthDp() {
+        return mInitScreenWidthDp;
+    }
+
+    /**
+     * 获取 {@link #mInitScreenHeightDp}
+     *
+     * @return {@link #mInitScreenHeightDp}
+     */
+    public int getInitScreenHeightDp() {
+        return mInitScreenHeightDp;
     }
 
     /**

--- a/autosize/src/main/java/me/jessyan/autosize/DisplayMetricsInfo.java
+++ b/autosize/src/main/java/me/jessyan/autosize/DisplayMetricsInfo.java
@@ -33,12 +33,23 @@ public class DisplayMetricsInfo implements Parcelable {
     private int densityDpi;
     private float scaledDensity;
     private float xdpi;
+    private int screenWidthDp;
+    private int screenHeightDp;
 
     public DisplayMetricsInfo(float density, int densityDpi, float scaledDensity, float xdpi) {
         this.density = density;
         this.densityDpi = densityDpi;
         this.scaledDensity = scaledDensity;
         this.xdpi = xdpi;
+    }
+
+    public DisplayMetricsInfo(float density, int densityDpi, float scaledDensity, float xdpi, int screenWidthDp, int screenHeightDp) {
+        this.density = density;
+        this.densityDpi = densityDpi;
+        this.scaledDensity = scaledDensity;
+        this.xdpi = xdpi;
+        this.screenWidthDp = screenWidthDp;
+        this.screenHeightDp = screenHeightDp;
     }
 
     public float getDensity() {
@@ -73,6 +84,22 @@ public class DisplayMetricsInfo implements Parcelable {
         this.xdpi = xdpi;
     }
 
+    public int getScreenWidthDp() {
+        return screenWidthDp;
+    }
+
+    public void setScreenWidthDp(int screenWidthDp) {
+        this.screenWidthDp = screenWidthDp;
+    }
+
+    public int getScreenHeightDp() {
+        return screenHeightDp;
+    }
+
+    public void setScreenHeightDp(int screenHeightDp) {
+        this.screenHeightDp = screenHeightDp;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -84,6 +111,8 @@ public class DisplayMetricsInfo implements Parcelable {
         dest.writeInt(this.densityDpi);
         dest.writeFloat(this.scaledDensity);
         dest.writeFloat(this.xdpi);
+        dest.writeInt(this.screenWidthDp);
+        dest.writeInt(this.screenHeightDp);
     }
 
     protected DisplayMetricsInfo(Parcel in) {
@@ -91,6 +120,8 @@ public class DisplayMetricsInfo implements Parcelable {
         this.densityDpi = in.readInt();
         this.scaledDensity = in.readFloat();
         this.xdpi = in.readFloat();
+        this.screenWidthDp = in.readInt();
+        this.screenHeightDp = in.readInt();
     }
 
     public static final Creator<DisplayMetricsInfo> CREATOR = new Creator<DisplayMetricsInfo>() {
@@ -112,6 +143,8 @@ public class DisplayMetricsInfo implements Parcelable {
                 ", densityDpi=" + densityDpi +
                 ", scaledDensity=" + scaledDensity +
                 ", xdpi=" + xdpi +
+                ", screenWidthDp=" + screenWidthDp +
+                ", screenHeightDp=" + screenHeightDp +
                 '}';
     }
 }

--- a/autosize/src/main/java/me/jessyan/autosize/unit/UnitsManager.java
+++ b/autosize/src/main/java/me/jessyan/autosize/unit/UnitsManager.java
@@ -68,6 +68,10 @@ public class UnitsManager {
      * 是否支持副单位, 以什么为副单位? 默认不支持
      */
     private Subunits mSupportSubunits = Subunits.NONE;
+    /**
+     * 是否支持 ScreenSizeDp 修改, 默认不支持
+     */
+    private boolean isSupportScreenSizeDP = false;
 
     /**
      * 设置设计图尺寸
@@ -173,6 +177,25 @@ public class UnitsManager {
      */
     public Subunits getSupportSubunits() {
         return mSupportSubunits;
+    }
+
+    /**
+     * 是否支持 ScreenSizeDp 修改, 默认不支持, 详情请看类文件的注释 {@link UnitsManager}
+     *
+     * @return {@code true} 为支持, {@code false} 为不支持
+     */
+    public boolean isSupportScreenSizeDP() {
+        return isSupportScreenSizeDP;
+    }
+
+    /**
+     * 是否让 AndroidAutoSize 支持 ScreenSizeDp 修改, 默认不支持, 详情请看类文件的注释 {@link UnitsManager}
+     *
+     * @param supportScreenSizeDP {@code true} 为支持, {@code false} 为不支持
+     */
+    public UnitsManager setSupportScreenSizeDP(boolean supportScreenSizeDP) {
+        isSupportScreenSizeDP = supportScreenSizeDP;
+        return this;
     }
 
     /**


### PR DESCRIPTION
在使用[BasePopup](https://github.com/razerdp/BasePopup)这个库时发现的兼容性问题。
控件树测量过程中，如果Window设置了WRAP_CONTENT（一般在弹窗会这样设置），
ViewRootImpl.performTraversals会使用screenWidthDp、screenHeightDp作为测量值，
DecorView得到的测量结果和窗体的大小不一致，这时会用窗体的大小作为测量值再performMeasure一次。
正常情况下是没有问题的，在这个库中修改了DecorView的测量，使用screenWidthDp、screenHeightDp不正确的值测量时，DecorView得到了正确的测量结果（指的是和窗体大小一致），导致没有再测量一次，而这时DecorView的子View是用不正确的值测量出来的，出现适配问题。

假如一开始就使用正确的screenWidthDp、screenHeightDp就没有问题，所以修改了代码。

代码增加了isSupportScreenSizeDP字段，控制Configuration中的screenWidthDp和screenHeightDp适配，默认不开启。
当然这个设置也要isSupportSP为true的情况下才有效。