### PR TITLE
【2020.7.11】【1.使用阿里云仓库】

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,9 @@
 
 buildscript {
     repositories {
-        google()
+        maven{ url 'http://maven.aliyun.com/nexus/content/groups/public/'}
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
@@ -15,8 +16,9 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
+        maven{ url 'http://maven.aliyun.com/nexus/content/groups/public/'}
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
Google 仓库有墙，项目对于普通用户编译不过。可以优先使用阿里云仓库